### PR TITLE
Support new Logz.io CA cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/beats/filebeat:6.2.2
+FROM docker.elastic.co/beats/filebeat:6.8.9
 
 # Add custom filebeat config
 COPY filebeat.yml /usr/share/filebeat/filebeat.yml
@@ -8,10 +8,10 @@ USER root
 # Set permissions
 RUN chgrp filebeat /usr/share/filebeat/filebeat.yml
 
-# Get Logz.io CA cert
-RUN cd /usr/share/filebeat/ && curl -O https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt
+# Get Logz.io CA cert, updated for CA change, see https://docs.logz.io/technical-notes/chain-of-trust/#replace-the-cert-file
+RUN curl https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -o /usr/share/filebeat/Logzio_CA_Root.crt
 
 # Set permissions
-RUN chgrp filebeat /usr/share/filebeat/COMODORSADomainValidationSecureServerCA.crt
+RUN chgrp filebeat /usr/share/filebeat/Logzio_CA_Root.crt
 
 # Stay as root so we can read logs in /var/lib/docker/containers/*/*.log

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -36,5 +36,5 @@ filebeat.prospectors:
 logging.level: warning
 
 output.logstash:
-  hosts: ["listener-eu-catest.logz.io:5015"]
+  hosts: ["listener-eu.logz.io:5015"]
   ssl.certificate_authorities: ['/usr/share/filebeat/Logzio_CA_Root.crt']

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -36,5 +36,5 @@ filebeat.prospectors:
 logging.level: warning
 
 output.logstash:
-  hosts: ["listener-eu.logz.io:5015"]
-  ssl.certificate_authorities: ['/usr/share/filebeat/COMODORSADomainValidationSecureServerCA.crt']
+  hosts: ["listener-eu-catest.logz.io:5015"]
+  ssl.certificate_authorities: ['/usr/share/filebeat/Logzio_CA_Root.crt']


### PR DESCRIPTION
Changes to support new Logz.io CA cert as per https://docs.logz.io/technical-notes/chain-of-trust/#replace-the-cert-file. Includes using a more generic cert filename (rather than keep modifying filebeat.yml in future).

Also update to latest 6.x Filebeat release.