### PR TITLE
Update base image to Filebeat 6.8.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/beats/filebeat:6.8.9
+FROM docker.elastic.co/beats/filebeat-oss:6.8.16
 
 # Add custom filebeat config
 COPY filebeat.yml /usr/share/filebeat/filebeat.yml

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,4 +1,4 @@
-filebeat.prospectors:
+filebeat.inputs:
   - type: log
     paths:
       - /var/lib/docker/containers/*/*.log


### PR DESCRIPTION
Use OSS variant to ensure there are no licensing issues. This the latest 6.x release, staying with this to avoid breaking changes. This resolves a number of known vulnerabilities in the base image, though sadly not all.

Also see https://www.docker.elastic.co/r/beats/filebeat-oss:6.8.16

[ch527]